### PR TITLE
Integrate IREE at google/iree@dffa2106

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,8 +33,8 @@ jobs:
           -GNinja \
           -DCMAKE_C_COMPILER=clang-10 \
           -DCMAKE_CXX_COMPILER=clang++-10 \
-          -DIREE_HAL_DRIVERS_TO_BUILD="VMLA" \
-          -DIREE_TARGET_BACKENDS_TO_BUILD="VMLA"
+          -DIREE_HAL_DRIVERS_TO_BUILD="VMVX" \
+          -DIREE_TARGET_BACKENDS_TO_BUILD="VMVX"
         cmake --build . --target extern_custom_modules_test simple_embedding_test
         ./custom_modules/extern_custom_modules_test
         ./simple_embedding/simple_embedding_test

--- a/custom_modules/CMakeLists.txt
+++ b/custom_modules/CMakeLists.txt
@@ -35,23 +35,22 @@ add_custom_command(
 
 
 #-------------------------------------------------------------------------------
-# Embedd the VM bytcode module into a cc file via `generate_embed_data`.
+# Embedd the VM bytcode module into a c file via `generate_embed_data`.
 #-------------------------------------------------------------------------------
 
 # Define arguments passed to generate_embed_data
 set(_ARGS)
 list(APPEND _ARGS "--output_header=custom_modules_test_module.h")
-list(APPEND _ARGS "--output_impl=custom_modules_test_module.cc")
+list(APPEND _ARGS "--output_impl=custom_modules_test_module.c")
 list(APPEND _ARGS "--identifier=custom_modules_test_module")
-list(APPEND _ARGS "--cpp_namespace=iree::samples::custom_modules")
 list(APPEND _ARGS "--flatten")
 list(APPEND _ARGS "custom_modules_test_module.vmfb")
 
-# Embed VM bytecode module into cc source file
+# Embed VM bytecode module into c source file
 add_custom_command(
   OUTPUT
     "custom_modules_test_module.h"
-    "custom_modules_test_module.cc"
+    "custom_modules_test_module.c"
   COMMAND generate_embed_data ${_ARGS}
   DEPENDS generate_embed_data custom_modules_test_module.vmfb
 )
@@ -61,10 +60,10 @@ add_custom_command(
 # Create a library and thus a CMake target.
 #-------------------------------------------------------------------------------
 
-add_library(custom_modules_test_module_cc STATIC "")
-target_sources(custom_modules_test_module_cc
+add_library(custom_modules_test_module_c STATIC "")
+target_sources(custom_modules_test_module_c
   PRIVATE
-    custom_modules_test_module.cc
+    custom_modules_test_module.c
     custom_modules_test_module.h
 )
 
@@ -89,12 +88,12 @@ target_include_directories(extern_custom_modules_test
 )
 
 target_link_libraries(extern_custom_modules_test
-  custom_modules_test_module_cc
+  custom_modules_test_module_c
   native_module
   iree_base_base
   iree_base_logging
   iree_hal_hal
-  iree_hal_vmla_registration_registration
+  iree_hal_vmvx_registration_registration
   iree_modules_hal_hal
   iree_testing_gtest
   iree_testing_gtest_main

--- a/custom_modules/custom_modules_test.cc
+++ b/custom_modules/custom_modules_test.cc
@@ -20,7 +20,7 @@
 #include "iree/base/api.h"
 #include "iree/base/logging.h"
 #include "iree/hal/api.h"
-#include "iree/hal/vmla/registration/driver_module.h"
+#include "iree/hal/vmvx/registration/driver_module.h"
 #include "iree/modules/hal/hal_module.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
@@ -33,7 +33,7 @@ namespace {
 class CustomModulesTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
-    IREE_CHECK_OK(iree_hal_vmla_driver_module_register(
+    IREE_CHECK_OK(iree_hal_vmvx_driver_module_register(
         iree_hal_driver_registry_default()));
   }
 
@@ -45,7 +45,7 @@ class CustomModulesTest : public ::testing::Test {
     // TODO(benvanik): make a 'don't care' helper method.
     iree_hal_driver_t* hal_driver = nullptr;
     IREE_CHECK_OK(iree_hal_driver_registry_try_create_by_name(
-        iree_hal_driver_registry_default(), iree_make_cstring_view("vmla"),
+        iree_hal_driver_registry_default(), iree_make_cstring_view("vmvx"),
         iree_allocator_system(), &hal_driver));
     iree_hal_device_t* hal_device = nullptr;
     IREE_CHECK_OK(iree_hal_driver_create_default_device(
@@ -62,7 +62,7 @@ class CustomModulesTest : public ::testing::Test {
         << "Native module failed to init";
 
     const auto* module_file_toc =
-        iree::samples::custom_modules::custom_modules_test_module_create();
+        custom_modules_test_module_create();
     IREE_CHECK_OK(iree_vm_bytecode_module_create(
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(module_file_toc->data),

--- a/custom_modules/dialect/CMakeLists.txt
+++ b/custom_modules/dialect/CMakeLists.txt
@@ -141,23 +141,22 @@ add_dependencies(custom_ops_gen custom_ops_gen_target)
 
 
 #-------------------------------------------------------------------------------
-# Embedd the MLIR file into a cc file via `generate_embed_data`.
+# Embedd the MLIR file into a c file via `generate_embed_data`.
 #-------------------------------------------------------------------------------
 
 # Define arguments passed to generate_embed_data
 set(_ARGS)
 list(APPEND _ARGS "--output_header=custom.imports.h")
-list(APPEND _ARGS "--output_impl=custom.imports.cc")
+list(APPEND _ARGS "--output_impl=custom.imports.c")
 list(APPEND _ARGS "--identifier=custom_imports")
-list(APPEND _ARGS "--cpp_namespace=mlir::iree_compiler::IREE::Custom")
 list(APPEND _ARGS "--flatten")
 list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/custom.imports.mlir")
 
-# Embed the MLIR file into cc source file
+# Embed the MLIR file into c source file
 add_custom_command(
   OUTPUT
     "custom.imports.h"
-    "custom.imports.cc"
+    "custom.imports.c"
   COMMAND generate_embed_data ${_ARGS}
   DEPENDS generate_embed_data custom.imports.mlir
 )
@@ -170,6 +169,6 @@ add_custom_command(
 add_library(custom_imports STATIC "")
 target_sources(custom_imports
   PRIVATE
-    custom.imports.cc
+    custom.imports.c
     custom.imports.h
 )

--- a/simple_embedding/CMakeLists.txt
+++ b/simple_embedding/CMakeLists.txt
@@ -20,7 +20,7 @@ set(_TRANSLATE_TOOL_EXECUTABLE $<TARGET_FILE:iree_tools_iree-translate>)
 # Define arguments passed to iree-translate
 set(_ARGS)
 list(APPEND _ARGS "-iree-mlir-to-vm-bytecode-module")
-list(APPEND _ARGS "-iree-hal-target-backends=vmla")
+list(APPEND _ARGS "-iree-hal-target-backends=vmvx")
 # Uncomment the line below to use vulkan-spirv backend
 #list(APPEND _ARGS "-iree-hal-target-backends=vulkan-spirv")
 list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/simple_embedding_test.mlir")
@@ -36,23 +36,22 @@ add_custom_command(
 
 
 #-------------------------------------------------------------------------------
-# Embedd the VM bytcode module into a cc file via `generate_embed_data`.
+# Embedd the VM bytcode module into a c file via `generate_embed_data`.
 #-------------------------------------------------------------------------------
 
 # Define arguments passed to generate_embed_data
 set(_ARGS)
 list(APPEND _ARGS "--output_header=simple_embedding_test_bytecode_module.h")
-list(APPEND _ARGS "--output_impl=simple_embedding_test_bytecode_module.cc")
+list(APPEND _ARGS "--output_impl=simple_embedding_test_bytecode_module.c")
 list(APPEND _ARGS "--identifier=simple_embedding_test_bytecode_module")
-list(APPEND _ARGS "--cpp_namespace=iree::samples")
 list(APPEND _ARGS "--flatten")
 list(APPEND _ARGS "simple_embedding_test_bytecode_module.vmfb")
 
-# Embed VM bytecode module into cc source file
+# Embed VM bytecode module into c source file
 add_custom_command(
   OUTPUT
     "simple_embedding_test_bytecode_module.h"
-    "simple_embedding_test_bytecode_module.cc"
+    "simple_embedding_test_bytecode_module.c"
   COMMAND generate_embed_data ${_ARGS}
   DEPENDS generate_embed_data simple_embedding_test_bytecode_module.vmfb
 )
@@ -62,10 +61,10 @@ add_custom_command(
 # Create a library and thus a CMake target.
 #-------------------------------------------------------------------------------
 
-add_library(simple_embedding_test_bytecode_module_cc STATIC "")
-target_sources(simple_embedding_test_bytecode_module_cc
+add_library(simple_embedding_test_bytecode_module_c STATIC "")
+target_sources(simple_embedding_test_bytecode_module_c
   PRIVATE
-    simple_embedding_test_bytecode_module.cc
+    simple_embedding_test_bytecode_module.c
     simple_embedding_test_bytecode_module.h
 )
 
@@ -88,13 +87,13 @@ target_include_directories(simple_embedding_test
 )
 
 target_link_libraries(simple_embedding_test
-  simple_embedding_test_bytecode_module_cc
+  simple_embedding_test_bytecode_module_c
   absl_core_headers
   absl_strings
   iree_base_base
   iree_base_logging
   iree_hal_hal
-  iree_hal_vmla_registration_registration
+  iree_hal_vmvx_registration_registration
   # Uncomment the line below to use vulkan-spirv backend
   #iree_hal_vulkan_registration_registration
   iree_modules_hal_hal

--- a/simple_embedding/simple_embedding_test.cc
+++ b/simple_embedding/simple_embedding_test.cc
@@ -17,7 +17,7 @@
 #include "iree/base/api.h"
 #include "iree/base/logging.h"
 #include "iree/hal/api.h"
-#include "iree/hal/vmla/registration/driver_module.h"
+#include "iree/hal/vmvx/registration/driver_module.h"
 // Include the line below to use the vulkan backend.
 //#include "iree/hal/vulkan/registration/driver_module.h"
 #include "iree/modules/hal/hal_module.h"
@@ -44,14 +44,14 @@ std::ostream& operator<<(std::ostream& os, const TestParams& params) {
 }
 
 std::vector<TestParams> GetDriverTestParams() {
-  // The test file was compiled for VMLA+Vulkan, so test on each driver.
+  // The test file was compiled for VMVX+Vulkan, so test on each driver.
   std::vector<TestParams> test_params;
 
   IREE_CHECK_OK(
-      iree_hal_vmla_driver_module_register(iree_hal_driver_registry_default()));
-  TestParams vmla_params;
-  vmla_params.driver_name = "vmla";
-  test_params.push_back(std::move(vmla_params));
+      iree_hal_vmvx_driver_module_register(iree_hal_driver_registry_default()));
+  TestParams vmvx_params;
+  vmvx_params.driver_name = "vmvx";
+  test_params.push_back(std::move(vmvx_params));
 
   // Uncomment the code block below to test the vulkan backend.
   /*


### PR DESCRIPTION
This replaces VMLA with VMVX, as VMLA was dopped by upstream.
Furthermore, this adops the upstream change with that
`generate_embed_data` generates C instead of C++ code.